### PR TITLE
Rom verification performance enhancements

### DIFF
--- a/Mamesaver/ConfigForm.cs
+++ b/Mamesaver/ConfigForm.cs
@@ -132,7 +132,7 @@ namespace Mamesaver
 
         private void ListBuilder_DoWork(object sender, DoWorkEventArgs e)
         {
-            List<SelectableGame> gamesList = saver.GetGameList();
+            List<SelectableGame> gamesList = GameListBuilder.GetGameList();
             //TODO: Merge with existing list, if any
             e.Result = gamesList;
             

--- a/Mamesaver/GameListBuilder.cs
+++ b/Mamesaver/GameListBuilder.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace Mamesaver
+{
+    internal static class GameListBuilder
+    {
+        /// <summary>
+        /// Returns a <see cref="List{T}"/> of <see cref="SelectableGame"/>s which are read from
+        /// the full list and then merged with the verified rom's list. The games which are returned
+        /// all have a "good" status on their drivers. This check also eliminates BIOS ROMS.
+        /// </summary>
+        /// <returns>Returns a <see cref="List{T}"/> of <see cref="SelectableGame"/>s</returns>
+        public static List<SelectableGame> GetGameList()
+        {
+            // Retrieve identifiers of verified games
+            var verifiedGames = GetVerifiedSets();
+
+            var games = new List<SelectableGame>();
+
+            // Enrich game metadata
+            using (var stream = GetFullGameList())
+            {
+                var readerSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Parse };
+                using (var reader = XmlReader.Create(stream, readerSettings))
+                {
+                    reader.ReadStartElement("mame");
+
+                    // Read each machine, enriching metadata for verified sets
+                    while (reader.Read() && reader.Name == "machine")
+                    {
+                        // Read game metadata
+                        var element = (XElement)XNode.ReadFrom(reader);
+
+                        var name = element.Attribute("name")?.Value;
+                        if (name == null) continue;
+
+                        // Skip games which aren't verified
+                        if (!verifiedGames.ContainsKey(name)) continue;
+
+                        var driver = element.Element("driver");
+                        if (driver == null) continue;
+
+                        // Skip games which aren't fully emulated
+                        var status = driver.Attribute("status")?.Value;
+                        if (status != "good") continue;
+
+                        var year = element.Element("year")?.Value ?? "";
+                        var manufacturer = element.Element("manufacturer")?.Value ?? "";
+                        var description = element.Element("description")?.Value ?? "";
+
+                        games.Add(new SelectableGame(name, description, year, manufacturer, false));
+                    }
+                }
+            }
+
+            return games;
+        }
+
+        /// <summary>
+        ///     Returns a <see cref="IDictionary{TKey,TValue}" /> filled with the names of games which are
+        ///     verified to work. Only the ones marked as good are returned. The clone names
+        ///     are returned in the value of the hashtable while the name is used as the key.
+        /// </summary>
+        private static IDictionary<string, string> GetVerifiedSets()
+        {
+            var verifiedRoms = new Dictionary<string, string>();
+            var regex = new Regex(@"romset (\w*)(?:\s\[(\w*)\])? is good"); //only accept the "good" ROMS
+
+            // Verify each rom in directory
+            foreach (var rom in GetRomFiles())
+            {
+                // Retrieve state per rom
+                using (var stream = MameInvoker.GetOutput("-verifyroms", rom))
+                {
+                    var output = stream.ReadToEnd();
+                    if (!regex.IsMatch(output)) continue;
+
+                    var matches = regex.Match(output);
+                    verifiedRoms[matches.Groups[1].Value] = matches.Groups[2].Value;
+                }
+            }
+
+            return verifiedRoms;
+        }
+
+        /// <summary>
+        ///     Returns a list of the base name of roms in the Mame rom directories.
+        /// </summary>
+        /// <remarks>
+        ///     It is assumed that roms are zipped.
+        /// </remarks>
+        private static IEnumerable<string> GetRomFiles()
+        {
+            var roms = new List<string>();
+
+            foreach (var path in GetRomPaths())
+            {
+                var romFiles = Directory.GetFiles(path, "*.zip");
+                roms.AddRange(romFiles.Select(Path.GetFileNameWithoutExtension));
+            }
+
+            return roms;
+        }
+
+        /// <summary>
+        ///     Retrieves absolute paths to the rom directories as configured by Mame.
+        /// </summary>
+        /// <remarks>
+        ///     Multiple rom directories can be specified in Mame by separating directories by semicolons.
+        /// </remarks>
+        private static IEnumerable<string> GetRomPaths()
+        {
+            // Configuration in the Mame ini file which indicates path to roms
+            var regex = new Regex(@"rompath\s+(.*)");
+
+            using (var stream = MameInvoker.GetOutput("-showconfig"))
+            {
+                string line;
+                while ((line = stream.ReadLine()) != null)
+                {
+                    if (!regex.IsMatch(line)) continue;
+
+                    var match = regex.Match(line);
+                    var paths = match.Groups[1].Value.Split(';');
+
+                    // Construct list of absolute paths
+                    var absolutePaths = new List<string>();
+                    foreach (var path in paths.Select(p => p.Trim()))
+                    {
+                        // If path is absolute, return raw path
+                        if (Path.IsPathRooted(path))
+                        {
+                            absolutePaths.Add(path);
+                        }
+                        else
+                        {
+                            // If path is relative, return path relative to Mame executable
+                            var execPath = Settings.ExecutablePath;
+                            var workingDirectory = Directory.GetParent(execPath).ToString();
+
+                            absolutePaths.Add(Path.Combine(workingDirectory, path));
+                        }
+                    }
+
+                    return absolutePaths;
+                }
+            }
+
+            throw new InvalidOperationException("Unable to retrieve rom paths");
+        }
+
+        /// <summary>
+        ///     Gets the full XML game list from <a href="http://www.mame.org/">Mame</a>.
+        /// </summary>
+        /// <returns><see cref="StreamReader" /> containing stream of Mame XML</returns>
+        private static StreamReader GetFullGameList()
+        {
+            return MameInvoker.GetOutput("-listxml");
+        }
+    }
+}

--- a/Mamesaver/MameInvoker.cs
+++ b/Mamesaver/MameInvoker.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace Mamesaver
+{
+    internal static class MameInvoker
+    {
+        /// <summary>
+        ///     Invokes Mame, returning the created process
+        /// </summary>
+        /// <param name="arguments">arguments to pass to Mame</param>
+        public static Process Run(params string[] arguments)
+        {
+            var execPath = Settings.ExecutablePath;
+            var psi = new ProcessStartInfo(execPath)
+            {
+                Arguments = string.Join(" ", arguments),
+                WorkingDirectory = Directory.GetParent(execPath).ToString(),
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WindowStyle = ProcessWindowStyle.Hidden
+            };
+
+            var p = Process.Start(psi);
+            if (p == null) throw new InvalidOperationException($"Mame process not created: {psi.FileName} {psi.Arguments}");
+
+            return p;
+        }
+
+        /// <summary>
+        ///     Invokes Mame, returning the standard output stream
+        /// </summary>
+        /// <param name="arguments">raguments to pass to Mame</param>
+        public static StreamReader GetOutput(params string[] arguments)
+        {
+            return Run(arguments).StandardOutput;
+        }
+    }
+}

--- a/Mamesaver/Mamesaver.cs
+++ b/Mamesaver/Mamesaver.cs
@@ -4,18 +4,11 @@
  */
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Text.RegularExpressions;
 using System.Windows.Forms;
-using System.Xml;
-using System.Xml.Linq;
-using System.Xml.Serialization;
 using gma.System.Windows;
 
 namespace Mamesaver
@@ -112,59 +105,6 @@ namespace Mamesaver
             }
         }
 
-
-
-        /// <summary>
-        /// Returns a <see cref="List{T}"/> of <see cref="SelectableGame"/>s which are read from
-        /// the full list and then merged with the verified rom's list. The games which are returned
-        /// all have a "good" status on their drivers. This check also eliminates BIOS ROMS.
-        /// </summary>
-        /// <returns>Returns a <see cref="List{T}"/> of <see cref="SelectableGame"/>s</returns>
-        public List<SelectableGame> GetGameList()
-        {
-            // Retrieve identifiers of verified games
-            var verifiedGames = GetVerifiedSets();
-
-            var games = new List<SelectableGame>();
-
-            // Enrich game metadata
-            using (var stream = GetFullGameList())
-            {
-                var readerSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Parse };
-                using (var reader = XmlReader.Create(stream, readerSettings))
-                {
-                    reader.ReadStartElement("mame");
-
-                    // Read each machine, enriching metadata for verified sets
-                    while(reader.Read() && reader.Name == "machine")
-                    { 
-                        // Read game metadata
-                        var machine = (XElement) XNode.ReadFrom(reader);
-
-                        var name = machine.Attribute("name")?.Value;
-                        if (name == null) continue;
-                        
-                        // Skip games which aren't verified
-                        if (!verifiedGames.Contains(name)) continue;
-
-                        var driver = machine.Element("driver");
-                        if (driver == null) continue;
-
-                        // Skip games which aren't fully emulated
-                        var status = driver.Attribute("status")?.Value;
-                        if (status != "good") continue;
-
-                        var year = machine.Element("year")?.Value ?? "";
-                        var manufacturer = machine.Element("manufacturer")?.Value ?? "";
-                        var description = machine.Element("description")?.Value ?? "";
-
-                        games.Add(new SelectableGame(name, description, year, manufacturer, false));
-                    } 
-                }
-            }
-
-            return games;
-        }
         #endregion
 
         #region Event Hanlders
@@ -250,71 +190,11 @@ namespace Mamesaver
                 Application.DoEvents();
             }
 
-            // Set up the process
-            string execPath = Settings.ExecutablePath;
-            ProcessStartInfo psi = new ProcessStartInfo(execPath);
-            psi.Arguments = game.Name + " " + Settings.CommandLineOptions;
-            psi.WorkingDirectory = Directory.GetParent(execPath).ToString();
-            psi.CreateNoWindow = true;
-            psi.WindowStyle = ProcessWindowStyle.Hidden;
-
             // Start the timer and the process
             timer.Start();
-            return Process.Start(psi);
+            return MameInvoker.Run(game.Name, Settings.CommandLineOptions);
         }
 
-        /// <summary>
-        /// Gets the full XML game list from <a href="http://www.mame.org/">Mame</a>.
-        /// </summary>
-        /// <returns><see cref="String"/> holding the Mame XML</returns>
-        private StreamReader GetFullGameList()
-        {
-            string execPath = Settings.ExecutablePath;
-            ProcessStartInfo psi = new ProcessStartInfo(execPath);
-            psi.Arguments = "-listxml";
-            psi.WorkingDirectory = Directory.GetParent(execPath).ToString();
-            psi.RedirectStandardOutput = true;
-            psi.UseShellExecute = false;
-            psi.CreateNoWindow = true;
-            psi.WindowStyle = ProcessWindowStyle.Hidden;
-            Process p = Process.Start(psi);
-
-            return p.StandardOutput;
-
-        }
-
-        /// <summary>
-        /// Returns a <see cref="Hashtable"/> filled with the names of games which are
-        /// verified to work. Only the ones marked as good are returned. The clone names
-        /// are returned in the value of the hashtable while the name is used as the key.
-        /// </summary>
-        /// <returns><see cref="Hashtable"/></returns>
-        private Hashtable GetVerifiedSets()
-        {
-            string execPath = Settings.ExecutablePath;
-            ProcessStartInfo psi = new ProcessStartInfo(execPath);
-            psi.Arguments = "-verifyroms";
-            psi.WorkingDirectory = Directory.GetParent(execPath).ToString();
-            psi.RedirectStandardOutput = true;
-            psi.UseShellExecute = false;
-            psi.CreateNoWindow = true;
-            psi.WindowStyle = ProcessWindowStyle.Hidden;
-            Process p = Process.Start(psi);
-            string output = p.StandardOutput.ReadToEnd();
-            p.WaitForExit();
-
-
-            Regex r = new Regex(@"romset (\w*)(?:\s\[(\w*)\])? is good"); //only accept the "good" ROMS
-            MatchCollection matches = r.Matches(output);
-            Hashtable verifiedGames = new Hashtable();
-
-            foreach (Match m in matches)
-            {
-                verifiedGames.Add(m.Groups[1].Value, m.Groups[2].Value);
-            }
-
-            return verifiedGames;
-        }
-        #endregion
+       #endregion
     }
 }

--- a/Mamesaver/Mamesaver.csproj
+++ b/Mamesaver/Mamesaver.csproj
@@ -76,6 +76,8 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="ListViewSorter.cs" />
+    <Compile Include="MameInvoker.cs" />
+    <Compile Include="GameListBuilder.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Mamesaver.cs">


### PR DESCRIPTION
Refactored Mame game list operations into separate class, consolidated Mame invocation, significant performance enhancements for rom verification.

My change retrieves the rom path from the Mame configuration and runs the verify on each rom individually instead of asking Mame for the state of every single supported rom.

Multiple absolute and relative rom directories are supported and tested. Currently, only zipped roms are supported - I'm assuming this covers the majority of situations.

Because this alternate approach for verifying roms is quite different from the original approach, it will require a bit of testing over a larger rom collection than I have available here.